### PR TITLE
add comment to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
 * [The complete editor bindings definition of MoreEmacs.](https://github.com/yas99en/moreemacsnb/blob/master/core/src/io/github/yas99en/moreemacsnb/core/actions/MoreEmacs-keybindings.xml)
     * [modifier symbols](http://bits.netbeans.org/8.0/javadoc/org-openide-util/org/openide/util/Utilities.html#stringToKey(java.lang.String))
 * For mac user, both option key and command key are assigned to meta key.
-    * [How to disable typing special characters when pressing option key in Mac OS X?](http://stackoverflow.com/questions/11876485/how-to-disable-typing-special-characters-when-pressing-option-key-in-mac-os-x)
+    * ~~[How to disable typing special characters when pressing option key in Mac OS X?](http://stackoverflow.com/questions/11876485/how-to-disable-typing-special-characters-when-pressing-option-key-in-mac-os-x)~~  
+    (Note: above workaround does not work on Yosemite and El Capitan...)
 
 |function|	binding|	description|
 |:-----------|:------------|:------------|


### PR DESCRIPTION
I found that the workaround for Mac option key problem does not work on El Capitan (and Yosemite).
I added a comment to README.md.
